### PR TITLE
fix: 整理代码，修复潜在问题

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,32 @@ clang-format -i entry/src/main/cpp/**/*.cpp
   - `checkPortUsed()` - Checks if a port is in use
   - Interacts with libqemu-system-aarch64.so
 
+### VNC Subsystem (`entry/src/main/cpp/`)
+Three-thread architecture for VNC display rendering:
+
+- **`napi_vnc.cpp`** - N-API bindings and poll thread management:
+  - Poll thread: `WaitForMessage` + `HandleRFBServerMessage` loop (protected by `socketMutex_`)
+  - TSFN notifications to JS for resize (status=1) and disconnect (status=-1)
+  - Frame updates go directly to render thread via `markDirty()` (no TSFN)
+  - **Critical**: Do NOT send duplicate `SendFramebufferUpdateRequest` or `SendIncrementalFramebufferUpdateRequest` — `rfbInitConnection` and `HandleRFBServerMessage` already send these; duplicates cause QEMU stream desync
+
+- **`vnc_client.cpp`** / **`include/vnc_client.hpp`** - libvncclient wrapper:
+  - RGB565 pixel format (16bpp, redMax=0x1f, greenMax=0x3f, blueMax=0x1f, shifts 11/5/0)
+  - Encodings: zrle ultra hextile zlib copyrect raw (when LIBZ available)
+  - `readTimeout=0` (infinite): non-zero causes spurious timeouts during ZRLE/zlib decode
+  - `useRemoteCursor=FALSE`: QEMU cursor pseudo-encodings may cause stream desync
+  - All socket I/O serialized via `socketMutex_` (libvncclient is NOT thread-safe)
+  - `rfbClientLog`/`rfbClientErr` redirected to HiLog
+
+- **`vnc_renderer.cpp`** / **`include/vnc_renderer.hpp`** - OpenGL ES renderer:
+  - Render thread owns EGL context (JS thread releases after `init()`)
+  - Condition variable wakeup on `markDirty()` or `surfaceResized_`
+  - GLES 3.0 with GLES 2.0 fallback (VAO available on GLES 3.0)
+  - Letterbox viewport via `calcViewport()` for aspect ratio preservation
+  - `updateTexture()`: full `glTexImage2D` on resize, partial `glTexSubImage2D` for dirty regions (GLES 3.0), full fallback (GLES 2.0)
+
+- **`utils.cpp`** / **`include/utils.hpp`** - HarmonyOS keycode to RFB keysym mapping
+
 ### Resources
 - `entry/src/main/resources/rawfile/vm/` - Kernel and root filesystem images
 - `entry/src/main/resources/rawfile/novnc/` - NoVNC web VNC client

--- a/entry/src/main/cpp/include/vnc_client.hpp
+++ b/entry/src/main/cpp/include/vnc_client.hpp
@@ -42,6 +42,10 @@ public:
     static int getFrameHeight();
     static rfbClient* getClient();
 
+    // Framebuffer mutex: protects frameBuffer_/fbWidth_/fbHeight_ across threads.
+    // onResize (poll thread) writes, updateTexture (render thread) reads.
+    static std::mutex& getFbMutex() { return fbMutex_; }
+
     // Socket mutex: libvncclient is NOT thread-safe, all socket I/O must be serialized
     static std::mutex& getSocketMutex() { return socketMutex_; }
 
@@ -55,6 +59,7 @@ private:
     static uint8_t* frameBuffer_;
     static int fbWidth_;
     static int fbHeight_;
+    static std::mutex fbMutex_;
 
     static VncResizeCallback resizeCallback_;
     static VncFrameCallback frameCallback_;

--- a/entry/src/main/cpp/napi_vnc.cpp
+++ b/entry/src/main/cpp/napi_vnc.cpp
@@ -13,6 +13,12 @@
 //   - sendMouseEvent/sendKeyEvent use socketMutex_ to avoid blocking poll thread
 //   - Render thread only reads VNC framebuffer (no socket I/O)
 //
+// Protocol notes:
+//   - Do NOT send SendFramebufferUpdateRequest: rfbInitConnection already sends one
+//   - Do NOT send SendIncrementalFramebufferUpdateRequest: HandleRFBServerMessage
+//     sends one internally after each FramebufferUpdate (rfbclient.c:2564)
+//   - Duplicate requests cause QEMU to produce extra responses that desync the stream
+//
 
 #include "napi/native_api.h"
 #include <cassert>
@@ -21,7 +27,6 @@
 #include <thread>
 #include <atomic>
 #include <mutex>
-#include <chrono>
 
 #include "hilog/log.h"
 #undef LOG_DOMAIN
@@ -44,7 +49,7 @@ static napi_threadsafe_function g_tsfn = nullptr;
 // Pre-allocated notify data pool
 static constexpr int NOTIFY_POOL_SIZE = 4;
 struct VncNotifyData {
-    int status;         // 1=resize, -1=disconnected (no more 2=frame)
+    int status;         // 1=resize, -1=disconnected
     int fbWidth;
     int fbHeight;
     bool inUse;
@@ -73,16 +78,23 @@ static void freeNotifyData(VncNotifyData* nd) {
     }
 }
 
-// Diagnostics: frame counter (declared in vnc_renderer.cpp)
-extern std::atomic<int> g_tsfnCallCount;
+// Safely call TSFN: if the call fails (TSFN closing/full), free the notify data to avoid leak
+static void notifyJs(VncNotifyData* nd) {
+    if (!g_tsfn) {
+        freeNotifyData(nd);
+        return;
+    }
+    napi_status status = napi_call_threadsafe_function(g_tsfn, nd, napi_tsfn_nonblocking);
+    if (status != napi_ok) {
+        freeNotifyData(nd);
+    }
+}
 
 static void tsfnCallJs(napi_env env, napi_value js_cb, void* context, void* data) {
     if (!env || !js_cb || !data) return;
 
     VncNotifyData* nd = static_cast<VncNotifyData*>(data);
-    g_tsfnCallCount.fetch_add(1, std::memory_order_relaxed);
 
-    // All notifications go to JS callback (resize/disconnect only now)
     napi_value jsObj;
     napi_create_object(env, &jsObj);
 
@@ -105,18 +117,6 @@ static void tsfnCallJs(napi_env env, napi_value js_cb, void* context, void* data
 static void vncPollThread() {
     OH_LOG_INFO(LOG_APP, "VNC poll thread started");
 
-    // NOTE: Do NOT send an initial SendFramebufferUpdateRequest here.
-    // rfbInitClient -> rfbInitConnection already sends one (vncviewer.c line 422).
-    // Sending a duplicate would cause QEMU to send two full FramebufferUpdate
-    // responses, which can lead to stream desync.
-
-    // Poll loop diagnostics
-    static constexpr int LOG_EVERY_N = 500;
-    int pollCount = 0;
-    int msgCount = 0;
-    int errorCount = 0;
-    auto lastLogTime = std::chrono::steady_clock::now();
-
     while (g_pollRunning.load()) {
         rfbClient* cl = VncClient::getClient();
         if (!cl) {
@@ -127,60 +127,32 @@ static void vncPollThread() {
         {
             std::lock_guard<std::mutex> lock(VncClient::getSocketMutex());
             int i = WaitForMessage(cl, 50);
-            pollCount++;
 
             if (!g_pollRunning.load()) break;
 
             if (i < 0) {
-                errorCount++;
-                OH_LOG_ERROR(LOG_APP, "Poll: WaitForMessage error (sock=%{public}d errno=%{public}d) "
-                            "pollCount=%{public}d msgCount=%{public}d errorCount=%{public}d",
-                            cl->sock, errno, pollCount, msgCount, errorCount);
-                if (g_tsfn) {
-                    auto* nd = allocNotifyData();
-                    nd->status = -1; nd->fbWidth = 0; nd->fbHeight = 0;
-                    napi_call_threadsafe_function(g_tsfn, nd, napi_tsfn_nonblocking);
-                }
+                OH_LOG_ERROR(LOG_APP, "Poll: WaitForMessage error (sock=%{public}d errno=%{public}d)",
+                            cl->sock, errno);
+                auto* nd = allocNotifyData();
+                nd->status = -1; nd->fbWidth = 0; nd->fbHeight = 0;
+                notifyJs(nd);
                 break;
             }
 
             if (i > 0) {
-                msgCount++;
                 if (!HandleRFBServerMessage(cl)) {
-                    errorCount++;
-                    OH_LOG_ERROR(LOG_APP, "Poll: HandleRFBServerMessage returned FALSE "
-                                "(sock=%{public}d errno=%{public}d cl->width=%{public}d cl->height=%{public}d) "
-                                "pollCount=%{public}d msgCount=%{public}d errorCount=%{public}d",
-                                cl->sock, errno, cl->width, cl->height,
-                                pollCount, msgCount, errorCount);
-                    if (g_tsfn) {
-                        auto* nd = allocNotifyData();
-                        nd->status = -1; nd->fbWidth = 0; nd->fbHeight = 0;
-                        napi_call_threadsafe_function(g_tsfn, nd, napi_tsfn_nonblocking);
-                    }
+                    OH_LOG_ERROR(LOG_APP, "Poll: HandleRFBServerMessage failed (sock=%{public}d errno=%{public}d)",
+                                cl->sock, errno);
+                    auto* nd = allocNotifyData();
+                    nd->status = -1; nd->fbWidth = 0; nd->fbHeight = 0;
+                    notifyJs(nd);
                     break;
                 }
             }
         }
-
-        // NOTE: Do NOT send SendIncrementalFramebufferUpdateRequest here.
-        // HandleRFBServerMessage already sends one after each FramebufferUpdate
-        // (rfbclient.c line 2564). Sending a duplicate causes QEMU to produce
-        // extra responses that accumulate and eventually desync the stream.
-
-        // Periodic diagnostics log
-        if (pollCount % LOG_EVERY_N == 0) {
-            auto now = std::chrono::steady_clock::now();
-            auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastLogTime).count();
-            lastLogTime = now;
-            OH_LOG_INFO(LOG_APP, "Poll stats: polls=%{public}d msgs=%{public}d errors=%{public}d "
-                        "interval=%{public}lldms",
-                        pollCount, msgCount, errorCount, static_cast<long long>(elapsedMs));
-        }
     }
 
-    OH_LOG_INFO(LOG_APP, "VNC poll thread stopped (polls=%{public}d msgs=%{public}d errors=%{public}d)",
-                pollCount, msgCount, errorCount);
+    OH_LOG_INFO(LOG_APP, "VNC poll thread stopped");
 }
 
 // ---- NAPI Functions ----
@@ -220,13 +192,11 @@ static napi_value vncInit(napi_env env, napi_callback_info info) {
     VncClient::setResizeCallback([](int width, int height) {
         OH_LOG_INFO(LOG_APP, "VNC resize: %{public}dx%{public}d", width, height);
         VncRenderer::resize(-1, -1);
-        if (g_tsfn) {
-            auto* nd = allocNotifyData();
-            nd->status = 1;
-            nd->fbWidth = width;
-            nd->fbHeight = height;
-            napi_call_threadsafe_function(g_tsfn, nd, napi_tsfn_nonblocking);
-        }
+        auto* nd = allocNotifyData();
+        nd->status = 1;
+        nd->fbWidth = width;
+        nd->fbHeight = height;
+        notifyJs(nd);
     });
 
     napi_value ret;
@@ -337,7 +307,7 @@ static napi_value vncStartUpdateLoop(napi_env env, napi_callback_info info) {
         nd->status = 1;
         nd->fbWidth = cl->width;
         nd->fbHeight = cl->height;
-        napi_call_threadsafe_function(g_tsfn, nd, napi_tsfn_nonblocking);
+        notifyJs(nd);
     }
 
     OH_LOG_INFO(LOG_APP, "vncStartUpdateLoop: thread started");

--- a/entry/src/main/cpp/vnc_client.cpp
+++ b/entry/src/main/cpp/vnc_client.cpp
@@ -18,14 +18,13 @@
 #define LOG_DOMAIN 0x3301
 #define LOG_TAG "VNCClient"
 
-// HiSH: redirect libvncserver logs to HiLog
+// Redirect libvncserver logs to HiLog
 static void hishVncLog(const char* format, ...) {
     char buf[512];
     va_list args;
     va_start(args, format);
     vsnprintf(buf, sizeof(buf), format, args);
     va_end(args);
-    // Strip trailing newline if present
     int len = strlen(buf);
     while (len > 0 && (buf[len-1] == '\n' || buf[len-1] == '\r'))
         buf[--len] = '\0';
@@ -52,6 +51,7 @@ char VncClient::password_[256] = {};
 uint8_t* VncClient::frameBuffer_ = nullptr;
 int VncClient::fbWidth_ = 0;
 int VncClient::fbHeight_ = 0;
+std::mutex VncClient::fbMutex_;
 
 VncResizeCallback VncClient::resizeCallback_ = nullptr;
 VncFrameCallback VncClient::frameCallback_ = nullptr;
@@ -59,21 +59,19 @@ std::mutex VncClient::socketMutex_;
 
 rfbBool VncClient::onResize(rfbClient* cl) {
     size_t size = static_cast<size_t>(cl->height) * cl->width * cl->format.bitsPerPixel / 8;
-    OH_LOG_INFO(LOG_APP, "Resize: %{public}dx%{public}d bpp=%{public}d size=%{public}zu "
-                "fmt(r%{public}d/g%{public}d/b%{public}d rs=%{public}d gs=%{public}d bs=%{public}d) "
-                "sock=%{public}d",
-                cl->width, cl->height, cl->format.bitsPerPixel, size,
-                cl->format.redMax, cl->format.greenMax, cl->format.blueMax,
-                cl->format.redShift, cl->format.greenShift, cl->format.blueShift,
-                cl->sock);
+    OH_LOG_INFO(LOG_APP, "Resize: %{public}dx%{public}d bpp=%{public}d",
+                cl->width, cl->height, cl->format.bitsPerPixel);
 
-    delete[] frameBuffer_;
-    frameBuffer_ = new uint8_t[size];
-    memset(frameBuffer_, 0, size);
-    cl->frameBuffer = frameBuffer_;
+    {
+        std::lock_guard<std::mutex> lock(fbMutex_);
+        delete[] frameBuffer_;
+        frameBuffer_ = new uint8_t[size];
+        memset(frameBuffer_, 0, size);
+        cl->frameBuffer = frameBuffer_;
 
-    fbWidth_ = cl->width;
-    fbHeight_ = cl->height;
+        fbWidth_ = cl->width;
+        fbHeight_ = cl->height;
+    }
 
     if (resizeCallback_) {
         resizeCallback_(cl->width, cl->height);
@@ -83,28 +81,6 @@ rfbBool VncClient::onResize(rfbClient* cl) {
 }
 
 void VncClient::onUpdate(rfbClient* cl, int x, int y, int w, int h) {
-    static std::atomic<int> updateCount{0};
-    int count = updateCount.fetch_add(1, std::memory_order_relaxed);
-
-    /* HiSH diagnostic: sample framebuffer content on first few updates */
-    bool hasContent = false;
-    if (count < 20 || count % 100 == 0) {
-        int fbSize = cl->width * cl->height * (cl->format.bitsPerPixel / 8);
-        int checkBytes = std::min(fbSize, 1024);
-        uint8_t* fb = reinterpret_cast<uint8_t*>(cl->frameBuffer);
-        if (fb && checkBytes > 0) {
-            /* Sample at start and middle of dirty region */
-            int rowBytes = cl->width * (cl->format.bitsPerPixel / 8);
-            int sampleOffset = y * rowBytes + x * (cl->format.bitsPerPixel / 8);
-            for (int i = sampleOffset; i < std::min(sampleOffset + checkBytes, fbSize); i++) {
-                if (fb[i] != 0) { hasContent = true; break; }
-            }
-        }
-        OH_LOG_INFO(LOG_APP, "onUpdate #%{public}d: (%{public}d,%{public}d %{public}dx%{public}d) "
-                    "fb=%{public}dx%{public}d hasContent=%{public}d",
-                    count, x, y, w, h, cl->width, cl->height, hasContent);
-    }
-
     if (frameCallback_) {
         VncFrameInfo info = {
             .fbWidth = cl->width,
@@ -115,8 +91,6 @@ void VncClient::onUpdate(rfbClient* cl, int x, int y, int w, int h) {
             .h = h
         };
         frameCallback_(info);
-    } else {
-        OH_LOG_WARN(LOG_APP, "onUpdate: frameCallback is NULL!");
     }
 }
 
@@ -177,48 +151,33 @@ bool VncClient::connect(const char* address, int port, const char* passwd) {
     // Compression
     client_->appData.compressLevel = 5;
     client_->appData.qualityLevel = 1;
-    // Encodings ordered by preference:
-    // - zlib/zrle require LIBZ (enabled if zlib found at build time)
-    // - tight requires LIBZ + LIBJPEG (JPEG not available on HarmonyOS)
-    // - hextile/copyrect/raw/corre/rre always available
-    // - ultra requires minilzo (included)
 #ifdef LIBVNCSERVER_HAVE_LIBZ
     client_->appData.encodingsString = "zrle ultra hextile zlib copyrect raw";
 #else
     client_->appData.encodingsString = "ultra hextile copyrect raw";
 #endif
-    // Disable remote cursor: causes "Unknown message type" with QEMU VNC.
-    // Standard vncviewer defaults to useRemoteCursor=FALSE. Cursor
-    // pseudo-encodings (XCursor/RichCursor/PointerPos) add complexity
-    // and QEMU's cursor implementation may not interoperate cleanly.
-    // TODO: re-enable after verifying basic FramebufferUpdate stability.
+    // useRemoteCursor=FALSE: QEMU cursor pseudo-encodings may cause stream desync.
+    // Standard vncviewer defaults to FALSE.
     client_->appData.useRemoteCursor = FALSE;
     client_->GetPassword = VncClient::getPassword;
     client_->GotFrameBufferUpdate = VncClient::onUpdate;
     client_->connectTimeout = 5;
-    // readTimeout: 0 = infinite wait (default). Setting to 1s caused spurious
-    // ReadFromRFBServer timeouts during ZRLE/zlib decode of large frames,
-    // which made HandleRFBServerMessage return FALSE and killed the poll thread.
+    // readTimeout=0 (infinite): non-zero values cause spurious ReadFromRFBServer
+    // timeouts during ZRLE/zlib decode of large frames, killing the poll thread.
     client_->readTimeout = 0;
 
     if (!rfbInitClient(client_, 0, nullptr)) {
         OH_LOG_ERROR(LOG_APP, "rfbInitClient failed");
+        // rfbClientCleanup frees serverHost and other internal allocations
+        rfbClientCleanup(client_);
         client_ = nullptr;
         return false;
     }
 
     connected_.store(true);
-    OH_LOG_INFO(LOG_APP, "Connected: %{public}dx%{public}d sock=%{public}d bpp=%{public}d "
-                "encodings=[%{public}s] readTimeout=%{public}u compress=%{public}d quality=%{public}d "
-                "canHandleNewFBSize=%{public}d useRemoteCursor=%{public}d",
+    OH_LOG_INFO(LOG_APP, "Connected: %{public}dx%{public}d sock=%{public}d encodings=[%{public}s]",
                 client_->width, client_->height, client_->sock,
-                client_->format.bitsPerPixel,
-                client_->appData.encodingsString,
-                client_->readTimeout,
-                client_->appData.compressLevel,
-                client_->appData.qualityLevel,
-                client_->canHandleNewFBSize,
-                client_->appData.useRemoteCursor);
+                client_->appData.encodingsString);
     return true;
 }
 
@@ -237,10 +196,13 @@ void VncClient::disconnect() {
         client_ = nullptr;
     }
 
-    delete[] frameBuffer_;
-    frameBuffer_ = nullptr;
-    fbWidth_ = 0;
-    fbHeight_ = 0;
+    {
+        std::lock_guard<std::mutex> lock(fbMutex_);
+        delete[] frameBuffer_;
+        frameBuffer_ = nullptr;
+        fbWidth_ = 0;
+        fbHeight_ = 0;
+    }
 }
 
 bool VncClient::isConnected() {

--- a/entry/src/main/cpp/vnc_renderer.cpp
+++ b/entry/src/main/cpp/vnc_renderer.cpp
@@ -14,7 +14,6 @@
 #include <native_window/external_window.h>
 #include <cstring>
 #include <vector>
-#include <chrono>
 #include "hilog/log.h"
 
 #undef LOG_DOMAIN
@@ -100,11 +99,6 @@ std::condition_variable VncRenderer::renderWakeCv_;
 std::atomic<bool> VncRenderer::surfaceResized_(false);
 std::atomic<bool> VncRenderer::initialized_(false);
 
-// Diagnostics: frame counter
-std::atomic<int> g_renderFrameCount{0};
-std::atomic<int> g_dirtyMarkCount{0};
-std::atomic<int> g_tsfnCallCount{0};
-
 // ---- Helper: compile a GL shader ----
 static GLuint compileShader(GLenum type, const char* source) {
     GLuint shader = glCreateShader(type);
@@ -178,9 +172,6 @@ bool VncRenderer::initEGL(int64_t surfaceId) {
     }
     OH_LOG_INFO(LOG_APP, "EGL %{public}d.%{public}d", majorVersion, minorVersion);
 
-    const char* eglExts = eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
-    OH_LOG_INFO(LOG_APP, "EGL extensions: %{public}s", eglExts ? eglExts : "(null)");
-
     const EGLint configAttribs[] = {
         EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT | EGL_OPENGL_ES3_BIT,
@@ -200,8 +191,6 @@ bool VncRenderer::initEGL(int64_t surfaceId) {
         return false;
     }
 
-    OH_LOG_INFO(LOG_APP, "Found %{public}d EGL configs, searching for compatible one", numConfigs);
-
     std::vector<EGLConfig> configs(numConfigs);
     if (!eglChooseConfig(eglDisplay_, configAttribs, configs.data(), numConfigs, &numConfigs)) {
         OH_LOG_ERROR(LOG_APP, "eglChooseConfig failed: err=%{public}d", eglGetError());
@@ -213,28 +202,18 @@ bool VncRenderer::initEGL(int64_t surfaceId) {
 
     eglConfig_ = nullptr;
     for (int i = 0; i < numConfigs; i++) {
-        EGLint redSize = 0, greenSize = 0, blueSize = 0, alphaSize = 0, renderable = 0, depthSize = 0, stencilSize = 0;
-        eglGetConfigAttrib(eglDisplay_, configs[i], EGL_RED_SIZE, &redSize);
-        eglGetConfigAttrib(eglDisplay_, configs[i], EGL_GREEN_SIZE, &greenSize);
-        eglGetConfigAttrib(eglDisplay_, configs[i], EGL_BLUE_SIZE, &blueSize);
-        eglGetConfigAttrib(eglDisplay_, configs[i], EGL_ALPHA_SIZE, &alphaSize);
-        eglGetConfigAttrib(eglDisplay_, configs[i], EGL_RENDERABLE_TYPE, &renderable);
+        EGLint depthSize = 0, stencilSize = 0;
         eglGetConfigAttrib(eglDisplay_, configs[i], EGL_DEPTH_SIZE, &depthSize);
         eglGetConfigAttrib(eglDisplay_, configs[i], EGL_STENCIL_SIZE, &stencilSize);
-
-        OH_LOG_INFO(LOG_APP, "  Config[%{public}d]: R%{public}dG%{public}dB%{public}dA%{public}d D%{public}dS%{public}d renderable=0x%{public}x",
-                    i, redSize, greenSize, blueSize, alphaSize, depthSize, stencilSize, renderable);
 
         if (depthSize > 0 || stencilSize > 0) continue;
 
         eglSurface_ = eglCreateWindowSurface(eglDisplay_, configs[i], (EGLNativeWindowType)nativeWindow, nullptr);
         if (eglSurface_ != nullptr) {
             eglConfig_ = configs[i];
-            OH_LOG_INFO(LOG_APP, "Using config[%{public}d]", i);
+            OH_LOG_INFO(LOG_APP, "Using EGL config[%{public}d]", i);
             break;
         }
-        EGLint surfErr = eglGetError();
-        OH_LOG_WARN(LOG_APP, "  Config[%{public}d] surface failed: 0x%{public}x", i, surfErr);
     }
 
     if (eglConfig_ == nullptr) {
@@ -243,7 +222,7 @@ bool VncRenderer::initEGL(int64_t surfaceId) {
             eglSurface_ = eglCreateWindowSurface(eglDisplay_, configs[i], (EGLNativeWindowType)nativeWindow, nullptr);
             if (eglSurface_ != nullptr) {
                 eglConfig_ = configs[i];
-                OH_LOG_INFO(LOG_APP, "Fallback: using config[%{public}d]", i);
+                OH_LOG_INFO(LOG_APP, "Fallback: using EGL config[%{public}d]", i);
                 break;
             }
         }
@@ -256,15 +235,6 @@ bool VncRenderer::initEGL(int64_t surfaceId) {
         OH_NativeWindow_DestroyNativeWindow(nativeWindow);
         return false;
     }
-
-    EGLint redSize = 0, greenSize = 0, blueSize = 0, alphaSize = 0, renderable = 0;
-    eglGetConfigAttrib(eglDisplay_, eglConfig_, EGL_RED_SIZE, &redSize);
-    eglGetConfigAttrib(eglDisplay_, eglConfig_, EGL_GREEN_SIZE, &greenSize);
-    eglGetConfigAttrib(eglDisplay_, eglConfig_, EGL_BLUE_SIZE, &blueSize);
-    eglGetConfigAttrib(eglDisplay_, eglConfig_, EGL_ALPHA_SIZE, &alphaSize);
-    eglGetConfigAttrib(eglDisplay_, eglConfig_, EGL_RENDERABLE_TYPE, &renderable);
-    OH_LOG_INFO(LOG_APP, "Chosen EGL config: R%{public}dG%{public}dB%{public}dA%{public}d renderable=0x%{public}x",
-                redSize, greenSize, blueSize, alphaSize, renderable);
 
     // Try GLES 3.x first, fallback to GLES 2.0
     const EGLint contextAttribs3[] = {
@@ -307,12 +277,7 @@ bool VncRenderer::initEGL(int64_t surfaceId) {
 
     const char* glVersion = reinterpret_cast<const char*>(glGetString(GL_VERSION));
     const char* glRenderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
-    const char* glVendor = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
-    const char* glslVersion = reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
-    OH_LOG_INFO(LOG_APP, "GL_VERSION: %{public}s", glVersion ? glVersion : "(null)");
-    OH_LOG_INFO(LOG_APP, "GL_RENDERER: %{public}s", glRenderer ? glRenderer : "(null)");
-    OH_LOG_INFO(LOG_APP, "GL_VENDOR: %{public}s", glVendor ? glVendor : "(null)");
-    OH_LOG_INFO(LOG_APP, "GLSL_VERSION: %{public}s", glslVersion ? glslVersion : "(null)");
+    OH_LOG_INFO(LOG_APP, "GL: %{public}s / %{public}s", glVersion ? glVersion : "(null)", glRenderer ? glRenderer : "(null)");
 
     EGLint eglWidth = 0, eglHeight = 0;
     eglQuerySurface(eglDisplay_, eglSurface_, EGL_WIDTH, &eglWidth);
@@ -335,8 +300,7 @@ bool VncRenderer::createShaders() {
             isGLES3 = (major >= 3);
         }
     }
-    OH_LOG_INFO(LOG_APP, "GL version detected: %{public}s, using %{public}s shaders",
-                glVersionStr ? glVersionStr : "(null)", isGLES3 ? "ES3" : "ES2");
+    OH_LOG_INFO(LOG_APP, "Using %{public}s shaders", isGLES3 ? "ES3" : "ES2");
 
     const char* vertSrc = isGLES3 ? VERTEX_SHADER_ES3 : VERTEX_SHADER_ES2;
     const char* fragSrc = isGLES3 ? FRAGMENT_SHADER_ES3 : FRAGMENT_SHADER_ES2;
@@ -395,9 +359,6 @@ bool VncRenderer::createShaders() {
     posLoc_ = glGetAttribLocation(shaderProgram_, "a_pos");
     texCoordLoc_ = glGetAttribLocation(shaderProgram_, "a_texCoord");
     texLoc_ = glGetUniformLocation(shaderProgram_, "u_tex");
-
-    OH_LOG_INFO(LOG_APP, "Shader locations: pos=%{public}d texCoord=%{public}d tex=%{public}d",
-                posLoc_, texCoordLoc_, texLoc_);
 
     if (posLoc_ < 0 || texCoordLoc_ < 0 || texLoc_ < 0) {
         OH_LOG_ERROR(LOG_APP, "Invalid shader attribute/uniform locations");
@@ -478,15 +439,6 @@ void VncRenderer::markDirty(int x, int y, int w, int h) {
         }
     }
     dirty_.store(true, std::memory_order_release);
-    int cnt = g_dirtyMarkCount.fetch_add(1, std::memory_order_relaxed);
-
-    /* HiSH diagnostic: log markDirty calls */
-    if (cnt < 10 || cnt % 100 == 0) {
-        OH_LOG_INFO(LOG_APP, "markDirty #%{public}d: (%{public}d,%{public}d %{public}dx%{public}d)",
-                    cnt, x, y, w, h);
-    }
-
-    // Wake render thread
     renderWakeCv_.notify_one();
 }
 
@@ -494,14 +446,12 @@ void VncRenderer::markDirty(int x, int y, int w, int h) {
 void VncRenderer::renderLoop() {
     OH_LOG_INFO(LOG_APP, "Render thread started");
 
-    // Make EGL context current on this thread
     if (!eglMakeCurrent(eglDisplay_, eglSurface_, eglSurface_, eglContext_)) {
         OH_LOG_ERROR(LOG_APP, "Render thread: eglMakeCurrent failed: 0x%{public}x", eglGetError());
         return;
     }
 
     while (renderRunning_.load(std::memory_order_acquire)) {
-        // Wait for wakeup signal (dirty or resize)
         {
             std::unique_lock<std::mutex> lk(renderWakeMutex_);
             renderWakeCv_.wait_for(lk, std::chrono::milliseconds(100),
@@ -512,23 +462,9 @@ void VncRenderer::renderLoop() {
 
         if (!renderRunning_.load(std::memory_order_acquire)) break;
 
-        /* HiSH diagnostic: log wake reasons periodically */
-        {
-            static std::atomic<int> wakeCount{0};
-            int wc = wakeCount.fetch_add(1, std::memory_order_relaxed);
-            if (wc < 10 || wc % 100 == 0) {
-                OH_LOG_INFO(LOG_APP, "renderLoop wake #%{public}d: dirty=%{public}d resized=%{public}d "
-                            "dirtyMarkTotal=%{public}d renderFrameTotal=%{public}d",
-                            wc, dirty_.load() ? 1 : 0, surfaceResized_.load() ? 1 : 0,
-                            g_dirtyMarkCount.load(std::memory_order_relaxed),
-                            g_renderFrameCount.load(std::memory_order_relaxed));
-            }
-        }
-
         renderFrameInternal();
     }
 
-    // Release context from this thread
     eglMakeCurrent(eglDisplay_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
     OH_LOG_INFO(LOG_APP, "Render thread stopped");
 }
@@ -557,14 +493,10 @@ void VncRenderer::renderFrameInternal() {
     bool needFullUpload = surfaceResized_.load(std::memory_order_acquire);
     if (needFullUpload) {
         surfaceResized_.store(false, std::memory_order_release);
-        OH_LOG_INFO(LOG_APP, "renderFrame: surface resize flagged, eglQuerySurface=%{public}dx%{public}d",
-                    surfWidth, surfHeight);
     }
 
     // Always sync surface dimensions from EGL — the source of truth
     if (surfWidth > 0 && surfHeight > 0 && (surfWidth != surfaceWidth_ || surfHeight != surfaceHeight_)) {
-        OH_LOG_INFO(LOG_APP, "renderFrame: surface dims changed %{public}dx%{public}d -> %{public}dx%{public}d",
-                    surfaceWidth_, surfaceHeight_, surfWidth, surfHeight);
         surfaceWidth_ = surfWidth;
         surfaceHeight_ = surfHeight;
         needFullUpload = true;
@@ -612,78 +544,48 @@ void VncRenderer::renderFrameInternal() {
     }
     glBindTexture(GL_TEXTURE_2D, 0);
 
-    GLenum glErr = glGetError();
-
     if (!eglSwapBuffers(eglDisplay_, eglSurface_)) {
-        EGLint err = eglGetError();
-        OH_LOG_ERROR(LOG_APP, "eglSwapBuffers failed: 0x%{public}x", err);
-    }
-
-    int frameNum = g_renderFrameCount.fetch_add(1, std::memory_order_relaxed);
-    if (frameNum < 5 || frameNum % 60 == 0) {
-        OH_LOG_INFO(LOG_APP, "renderFrame #%{public}d: dirty=(%{public}d,%{public}d,%{public}d,%{public}d) "
-                    "vnc=%{public}dx%{public}d surface=%{public}dx%{public}d vp=(%{public}d,%{public}d,%{public}d,%{public}d) "
-                    "glErr=0x%{public}x",
-                    frameNum, x, y, w, h, vncWidth_, vncHeight_, surfaceWidth_, surfaceHeight_,
-                    vpX, vpY, vpW, vpH, glErr);
+        OH_LOG_ERROR(LOG_APP, "eglSwapBuffers failed: 0x%{public}x", eglGetError());
     }
 }
 
 void VncRenderer::updateTexture(int x, int y, int w, int h, bool forceFull) {
     if (textureId_ == 0) return;
 
-    uint8_t* fb = VncClient::getFrameBuffer();
-    if (!fb) {
-        OH_LOG_WARN(LOG_APP, "updateTexture: framebuffer is NULL");
-        return;
-    }
-
-    int vw = VncClient::getFrameWidth();
-    int vh = VncClient::getFrameHeight();
-    if (vw <= 0 || vh <= 0) {
-        OH_LOG_WARN(LOG_APP, "updateTexture: invalid dimensions vw=%{public}d vh=%{public}d", vw, vh);
-        return;
-    }
-
-    // Diagnostic: check if framebuffer has non-zero content
+    int vw, vh;
+    uint8_t* fb;
     {
-        bool hasContent = false;
-        int checkBytes = std::min(vw * vh * 2, 256);
-        for (int i = 0; i < checkBytes; i++) {
-            if (fb[i] != 0) { hasContent = true; break; }
+        std::lock_guard<std::mutex> lock(VncClient::getFbMutex());
+        fb = VncClient::getFrameBuffer();
+        if (!fb) return;
+        vw = VncClient::getFrameWidth();
+        vh = VncClient::getFrameHeight();
+        if (vw <= 0 || vh <= 0) return;
+
+        glBindTexture(GL_TEXTURE_2D, textureId_);
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
+
+        if (forceFull || vw != vncWidth_ || vh != vncHeight_) {
+            vncWidth_ = vw;
+            vncHeight_ = vh;
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, vncWidth_, vncHeight_, 0,
+                         GL_RGB, GL_UNSIGNED_SHORT_5_6_5, fb);
+        } else if (vao_ != 0) {
+            glPixelStorei(GL_UNPACK_ROW_LENGTH, vncWidth_);
+            glPixelStorei(GL_UNPACK_SKIP_PIXELS, x);
+            glPixelStorei(GL_UNPACK_SKIP_ROWS, y);
+            glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h,
+                            GL_RGB, GL_UNSIGNED_SHORT_5_6_5, fb);
+            glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+            glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
+            glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
+        } else {
+            glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, vncWidth_, vncHeight_,
+                            GL_RGB, GL_UNSIGNED_SHORT_5_6_5, fb);
         }
-        static std::atomic<int> uploadCount{0};
-        int cnt = uploadCount.fetch_add(1, std::memory_order_relaxed);
-        if (cnt < 5 || cnt % 60 == 0) {
-            OH_LOG_INFO(LOG_APP, "updateTexture #%{public}d: forceFull=%{public}d rect=(%{public}d,%{public}d,%{public}d,%{public}d) "
-                        "fbSize=%{public}dx%{public}d hasContent=%{public}d",
-                        cnt, forceFull, x, y, w, h, vw, vh, hasContent);
-        }
+
+        glBindTexture(GL_TEXTURE_2D, 0);
     }
-
-    glBindTexture(GL_TEXTURE_2D, textureId_);
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
-
-    if (forceFull || vw != vncWidth_ || vh != vncHeight_) {
-        vncWidth_ = vw;
-        vncHeight_ = vh;
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, vncWidth_, vncHeight_, 0,
-                     GL_RGB, GL_UNSIGNED_SHORT_5_6_5, fb);
-    } else if (vao_ != 0) {
-        glPixelStorei(GL_UNPACK_ROW_LENGTH, vncWidth_);
-        glPixelStorei(GL_UNPACK_SKIP_PIXELS, x);
-        glPixelStorei(GL_UNPACK_SKIP_ROWS, y);
-        glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h,
-                        GL_RGB, GL_UNSIGNED_SHORT_5_6_5, fb);
-        glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-        glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
-        glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
-    } else {
-        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, vncWidth_, vncHeight_,
-                        GL_RGB, GL_UNSIGNED_SHORT_5_6_5, fb);
-    }
-
-    glBindTexture(GL_TEXTURE_2D, 0);
 }
 
 void VncRenderer::cleanupGL() {
@@ -755,23 +657,26 @@ bool VncRenderer::init(int64_t surfaceId) {
     }
 
     // Upload existing VNC framebuffer if already available
-    int vw = VncClient::getFrameWidth();
-    int vh = VncClient::getFrameHeight();
-    if (vw > 0 && vh > 0) {
-        uint8_t* fb = VncClient::getFrameBuffer();
-        if (fb) {
-            vncWidth_ = vw;
-            vncHeight_ = vh;
-            glBindTexture(GL_TEXTURE_2D, textureId_);
-            glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, vncWidth_, vncHeight_, 0,
-                         GL_RGB, GL_UNSIGNED_SHORT_5_6_5, fb);
-            glBindTexture(GL_TEXTURE_2D, 0);
-            OH_LOG_INFO(LOG_APP, "Uploaded initial framebuffer: %{public}dx%{public}d", vw, vh);
+    {
+        std::lock_guard<std::mutex> lock(VncClient::getFbMutex());
+        int vw = VncClient::getFrameWidth();
+        int vh = VncClient::getFrameHeight();
+        if (vw > 0 && vh > 0) {
+            uint8_t* fb = VncClient::getFrameBuffer();
+            if (fb) {
+                vncWidth_ = vw;
+                vncHeight_ = vh;
+                glBindTexture(GL_TEXTURE_2D, textureId_);
+                glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, vncWidth_, vncHeight_, 0,
+                             GL_RGB, GL_UNSIGNED_SHORT_5_6_5, fb);
+                glBindTexture(GL_TEXTURE_2D, 0);
+                OH_LOG_INFO(LOG_APP, "Uploaded initial framebuffer: %{public}dx%{public}d", vw, vh);
+            }
         }
     }
 
-    // Render initial frame (blue test + first VNC frame)
+    // Render initial frame
     {
         glViewport(0, 0, surfaceWidth_, surfaceHeight_);
         glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -834,7 +739,6 @@ void VncRenderer::shutdown() {
     if (!initialized_.load(std::memory_order_acquire)) return;
 
     // Now safe to cleanup — no other thread touches GL
-    // Re-make context current on this thread for cleanup
     if (eglDisplay_ != EGL_NO_DISPLAY && eglSurface_ != nullptr && eglContext_ != nullptr) {
         eglMakeCurrent(eglDisplay_, eglSurface_, eglSurface_, eglContext_);
     }
@@ -846,17 +750,18 @@ void VncRenderer::resize(int width, int height) {
 
     surfaceResized_.store(true, std::memory_order_release);
 
-    int vw = VncClient::getFrameWidth();
-    int vh = VncClient::getFrameHeight();
+    int vw, vh;
+    {
+        std::lock_guard<std::mutex> lock(VncClient::getFbMutex());
+        vw = VncClient::getFrameWidth();
+        vh = VncClient::getFrameHeight();
+    }
     if (vw > 0 && vh > 0) {
         markDirty(0, 0, vw, vh);
     } else {
         dirty_.store(true, std::memory_order_release);
     }
 
-    // Wake render thread
     renderWakeCv_.notify_one();
-
-    OH_LOG_INFO(LOG_APP, "resize: %{public}dx%{public}d, marked surfaceResized, vnc=%{public}dx%{public}d",
-                width, height, vw, vh);
+    OH_LOG_INFO(LOG_APP, "resize: surfaceResized flagged, vnc=%{public}dx%{public}d", vw, vh);
 }


### PR DESCRIPTION
已发现并修复的问题
1. 内存泄漏：rfbInitClient 失败时 serverHost 未释放（已修复） 位置：vnc_client.cpp:169
问题：strdup(address) 分配的 serverHost 在 rfbInitClient 失败后没有被清理 修复：失败时调用 rfbClientCleanup(client_) 释放内部所有分配
2. 内存泄漏：TSFN 调用失败时堆分配的 VncNotifyData 泄漏（已修复） 位置：napi_vnc.cpp 多处
问题：napi_call_threadsafe_function 可能返回非 napi_ok（TSFN 已关闭/队列满），此时 tsfnCallJs 不会被调用，VncNotifyData 永远不会被释放 修复：引入 notifyJs() 辅助函数，检查 TSFN 调用结果，失败时调用 freeNotifyData()
3. 竞态条件：framebuffer 指针在 poll 线程和 render 线程之间无保护（已修复） 位置：vnc_client.cpp onResize / vnc_renderer.cpp updateTexture 问题：onResize（poll 线程）delete[] frameBuffer_ 并重建，但 updateTexture（render 线程）通过 getFrameBuffer() 无锁读取同一指针，存在 use-after-free 风险 修复：新增 fbMutex_，在 onResize/disconnect 写入时加锁，在 updateTexture/resize/init 读取时加锁