### PR TITLE
fix: disable VNC by default to prevent crash on Pura X foldable

### DIFF
--- a/entry/src/main/ets/components/SettingsContent.ets
+++ b/entry/src/main/ets/components/SettingsContent.ets
@@ -46,7 +46,7 @@ export default struct SettingsContent {
   @Watch('saveTermCursorBlink') @StorageProp(appOption.terminalCursorBlink) termCursorBlink: boolean = false
   @Watch('saveRunningInBackground') @StorageProp(appOption.runningInBackground) runningInBackground: boolean = false
   @Watch('saveDisplayStatusBar') @StorageProp(appOption.displayStatusBar) displayStatusBar: boolean = false
-  @Watch('saveVncEnabled') @StorageProp(appOption.vncEnabled) vncEnabled: boolean = true
+  @Watch('saveVncEnabled') @StorageProp(appOption.vncEnabled) vncEnabled: boolean = false
   @Watch('saveVncPortMode') @StorageProp(appOption.vncPortMode) vncPortMode: string = 'local'
   @Watch('saveVncPort') @StorageProp(appOption.vncPort) vncPort: number = 5900
   @StorageProp('bundleInfo') bundleInfo?: bundleManager.BundleInfo = undefined

--- a/entry/src/main/ets/components/WebTerminal.ets
+++ b/entry/src/main/ets/components/WebTerminal.ets
@@ -36,7 +36,7 @@ export default struct WebTerminal {
   @Watch('onCursorShapeChanged') @StorageProp(appOption.terminalCursorShape) cursorShape: CursorShape | null = null
   @Watch('onCursorBlinkChanged') @StorageProp(appOption.terminalCursorBlink) cursorBlink: boolean | null = null
   @Watch('saveShowVirtKey') @StorageProp(appOption.showVirtKey) showVirtKey: boolean = true
-  @StorageProp(appOption.vncEnabled) vncEnabled: boolean = true
+  @StorageProp(appOption.vncEnabled) vncEnabled: boolean = false
   webviewController: WebviewController = new webview.WebviewController()
   utf8Decoder = util.TextDecoder.create('utf-8', { ignoreBOM: true })
   resizeTimeout?: number = undefined

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -225,7 +225,7 @@ export default class EntryAbility extends UIAbility {
     AppStorage.setOrCreate(appOption.terminalCursorShape, terminalCursorShape);
     const terminalCursorBlink = await appPref.get(appOption.terminalCursorBlink, false) as boolean;
     AppStorage.setOrCreate(appOption.terminalCursorBlink, terminalCursorBlink);
-    const vncEnabled = await appPref.get(appOption.vncEnabled, true) as boolean;
+    const vncEnabled = await appPref.get(appOption.vncEnabled, false) as boolean;
     AppStorage.setOrCreate(appOption.vncEnabled, vncEnabled);
     const vncPortMode = await appPref.get(appOption.vncPortMode, 'local') as string;
     AppStorage.setOrCreate(appOption.vncPortMode, vncPortMode);


### PR DESCRIPTION
## Problem

On HUAWEI Pura X (arm64-v8a), HiSH crashes with SIGABRT during startup.
The crash happens in QEMU `vnc_init_func` which calls `exit(1)` because
the VNC display backend fails to initialize on this device GPU/driver stack.
The app becomes completely unusable — it crashes before the UI finishes loading.

## Root Cause

Crash backtrace:
```
#03  libqemu-system-aarch64.so(vnc_init_func+476)
#04  libqemu-system-aarch64.so(qemu_opts_foreach+192)
#05  libqemu-system-aarch64.so(qemu_init+41192)
```

QEMU is launched with `-vnc 127.0.0.1:0 -device virtio-gpu-pci` by default,
but `vnc_init_func` cannot complete initialization on this device.

## Fix

Change the default value of `vncEnabled` from `true` to `false` in three places:

- `entry/src/main/ets/entryability/EntryAbility.ets` — initial preference default
- `entry/src/main/ets/components/SettingsContent.ets` — Settings UI component
- `entry/src/main/ets/components/WebTerminal.ets` — terminal UI component

When `vncEnabled` is `false`, QEMU is launched without `-vnc` and
`virtio-gpu-pci` options (handled by `startVm.ets` ternary guard),
avoiding the crash entirely.

Users who need VNC can still enable it in Settings → requires app restart.

## Testing

- Built and installed debug APK (v1.0.17) on HUAWEI Pura X (API 18)
- Without this fix: SIGABRT on every launch
- With this fix: app starts normally, VM boots successfully
- VNC toggle in Settings still works correctly when re-enabled