### PR TITLE
docs: fix broken star history chart in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,4 @@ mv rootfs.qcow2 feature/hish_main/src/main/resources/rawfile/vm/rootfs_aarch64.q
 
 # Star history
 
-[![星标历史图表](https://api.star-history.com/svg?repos=harmoninux/hish&type=Date)](https://www.star-history.com/#harmoninux/hish&Date)
+[![星标历史图表](https://star-history.dera.page/svg?repos=harmoninux/hish&type=Date)](https://star-history.dera.page/#harmoninux/hish&Date)

--- a/README_EN.md
+++ b/README_EN.md
@@ -132,4 +132,4 @@ qemu-img convert -p -f raw -O qcow2 rootfs.img rootfs.qcow2
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=harmoninux/hish&type=Date)](https://www.star-history.com/#harmoninux/hish&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=harmoninux/hish&type=Date)](https://star-history.dera.page/#harmoninux/hish&Date)


### PR DESCRIPTION
The star history chart shown in the README (and its English translation) is currently broken and no longer renders. This change is necessary to restore it. We switch the chart to an alternative provider that uses a different data source and works without an API token, and update the wrapping link to the matching new URL so the chart displays correctly again.