### PR TITLE
fix: only show JIT/AppGallery guide entries for AppGallery build

### DIFF
--- a/feature/hish_main/src/main/ets/components/SettingsContent.ets
+++ b/feature/hish_main/src/main/ets/components/SettingsContent.ets
@@ -326,7 +326,7 @@ export default struct SettingsContent {
               })
             }
 
-            if (!this.bundleInfo?.name.startsWith('dev.hackeris')) {
+            if (this.bundleInfo?.name === 'app.hackeris.hish') {
               LinkItem({
                 icon: $r('sys.symbol.star'),
                 title: $r('app.string.like_this_app'),


### PR DESCRIPTION
## 问题

设置页用 `!bundleInfo.name.startsWith('dev.hackeris')` 决定是否显示「喜欢这个应用」和「运行加速（JIT 说明）」两个入口：

https://github.com/harmoninux/HiSH/blob/master/feature/hish_main/src/main/ets/components/SettingsContent.ets#L329

这个判断把**所有不以 `dev.hackeris` 开头的包**都当成应用市场版。但实际上：

- `dev.hackeris.*` 只有作者本人的开发者账号能在 AGC 注册，任何其他人（包括按 README「自行签名安装 Release 版」或「源码编译」路线的用户）都必须改用别的包名
- 这些自建/自签包**都带 JIT**（libs.zip 打包的就是 JIT 版 libqemu），却被错误展示了「运行加速」引导页，页内文案声称当前版本「使用解释执行、不支持 JIT」——纯属误导

## 修改

判断改为精确匹配应用市场包名 `app.hackeris.hish`：

- 市场版（真正无 JIT 的那部分用户）：两个入口照常显示 ✓
- 源码编译 / Release 自签版（有 JIT）：不再显示误导性入口 ✓
- 作者本地开发版（`dev.hackeris.*`）：不显示，与原逻辑一致 ✓
